### PR TITLE
Fix broken setup.py

### DIFF
--- a/ipyevents/_version.py
+++ b/ipyevents/_version.py
@@ -3,7 +3,13 @@
 
 version_info = (0, 0, 2, 'dev', 1)
 
-_specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
+_specifier_ = {
+        'dev': 'dev', 
+        'alpha': 'a', 
+        'beta': 'b', 
+        'candidate': 'rc', 
+        'final': ''
+}
 
 __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
   '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))


### PR DESCRIPTION
Addresses issue #2.

Running `pip install .` breaks at the moment, because `_version.py` cannot be executed. This fixes it.

Thanks for writing this! I'm playing with it now.