### PR TITLE
Add compatibility with Jupyter lab

### DIFF
--- a/ipyevents/_version.py
+++ b/ipyevents/_version.py
@@ -14,4 +14,10 @@ _specifier_ = {
 __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
   '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))
 
-JS_EXTENSION_VERSION = '1.0.0'
+# The version of the attribute spec that this package
+# implements. This is the value used in
+# _model_module_version/_view_module_version.
+#
+# Update this value when attributes are added/removed from
+# your models, or serialized format changes.
+PROTOCOL_VERSION = '1.0.0'

--- a/ipyevents/_version.py
+++ b/ipyevents/_version.py
@@ -1,7 +1,7 @@
 # What a full version specifier looks like:
 # version_info = (0, 0, 1, 'alpha', 0)
 
-version_info = (1, 0, 0, 'final', 0)
+version_info = (0, 0, 2, 'dev', 1)
 
 _specifier_ = {
         'dev': 'dev',
@@ -13,3 +13,5 @@ _specifier_ = {
 
 __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
   '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))
+
+JS_EXTENSION_VERSION = '1.0.0'

--- a/ipyevents/_version.py
+++ b/ipyevents/_version.py
@@ -1,13 +1,13 @@
 # What a full version specifier looks like:
 # version_info = (0, 0, 1, 'alpha', 0)
 
-version_info = (0, 0, 2, 'dev', 1)
+version_info = (1, 0, 0, 'final', 0)
 
 _specifier_ = {
-        'dev': 'dev', 
-        'alpha': 'a', 
-        'beta': 'b', 
-        'candidate': 'rc', 
+        'dev': 'dev',
+        'alpha': 'a',
+        'beta': 'b',
+        'candidate': 'rc',
         'final': ''
 }
 

--- a/ipyevents/events.py
+++ b/ipyevents/events.py
@@ -3,15 +3,14 @@ from ipywidgets import DOMWidget
 from ipywidgets.widgets.trait_types import InstanceDict
 from ipywidgets import register, widget_serialization, CallbackDispatcher
 from traitlets import Unicode, List, Bool, validate
-from ._version import __version__ as EXTENSION_VERSION
+from ._version import JS_EXTENSION_VERSION
 
 
 @register
 class Event(CoreWidget):
     _model_name = Unicode('EventModel').tag(sync=True)
     _model_module = Unicode('ipyevents').tag(sync=True)
-    _view_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
-    _model_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
+    _model_module_version = Unicode(JS_EXTENSION_VERSION).tag(sync=True)
     source = InstanceDict(DOMWidget).tag(sync=True, **widget_serialization)
     watched_events = List().tag(sync=True)
     ignore_modifier_key_events = Bool(False).tag(sync=True)

--- a/ipyevents/events.py
+++ b/ipyevents/events.py
@@ -3,12 +3,15 @@ from ipywidgets import DOMWidget
 from ipywidgets.widgets.trait_types import InstanceDict
 from ipywidgets import register, widget_serialization, CallbackDispatcher
 from traitlets import Unicode, List, Bool, validate
+from ._version import __version__ as EXTENSION_VERSION
 
 
 @register
 class Event(CoreWidget):
     _model_name = Unicode('EventModel').tag(sync=True)
     _model_module = Unicode('ipyevents').tag(sync=True)
+    _view_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
+    _model_module_version = Unicode(EXTENSION_VERSION).tag(sync=True)
     source = InstanceDict(DOMWidget).tag(sync=True, **widget_serialization)
     watched_events = List().tag(sync=True)
     ignore_modifier_key_events = Bool(False).tag(sync=True)

--- a/ipyevents/events.py
+++ b/ipyevents/events.py
@@ -3,14 +3,14 @@ from ipywidgets import DOMWidget
 from ipywidgets.widgets.trait_types import InstanceDict
 from ipywidgets import register, widget_serialization, CallbackDispatcher
 from traitlets import Unicode, List, Bool, validate
-from ._version import JS_EXTENSION_VERSION
+from ._version import PROTOCOL_VERSION
 
 
 @register
 class Event(CoreWidget):
     _model_name = Unicode('EventModel').tag(sync=True)
     _model_module = Unicode('ipyevents').tag(sync=True)
-    _model_module_version = Unicode(JS_EXTENSION_VERSION).tag(sync=True)
+    _model_module_version = Unicode(PROTOCOL_VERSION).tag(sync=True)
     source = InstanceDict(DOMWidget).tag(sync=True, **widget_serialization)
     watched_events = List().tag(sync=True)
     ignore_modifier_key_events = Bool(False).tag(sync=True)

--- a/js/package.json
+++ b/js/package.json
@@ -28,14 +28,21 @@
     "build": "npm run build:src"
   },
   "devDependencies": {
+    "@phosphor/application": "^1.5.0",
+    "@phosphor/widgets": "^1.5.0",
     "webpack": "^3.5.5",
     "rimraf": "^2.6.1",
     "typescript": "~2.4.1",
     "@types/node": "^8.0.1"
   },
   "dependencies": {
+    "@phosphor/application": "^1.5.0",
+    "@phosphor/widgets": "^1.5.0",
     "@jupyter-widgets/base": "^1.0.4",
     "@jupyter-widgets/controls": "^1.0.5",
     "lodash": "^4.17.4"
+  },
+  "jupyterlab": {
+    "extension": "lib/plugin"
   }
 }

--- a/js/src/events.ts
+++ b/js/src/events.ts
@@ -3,7 +3,7 @@ import {
 } from '@jupyter-widgets/base';
 
 import {
-  JUPYTER_EXTENSION_VERSION
+  PROTOCOL_VERSION
 } from './version';
 
 import * as _ from 'underscore';
@@ -93,7 +93,7 @@ class EventModel extends WidgetModel {
         return _.extend(super.defaults(), {
             _model_name: 'EventModel',
             _model_module: 'ipyevents',
-            _model_module_version: JUPYTER_EXTENSION_VERSION,
+            _model_module_version: PROTOCOL_VERSION,
             source: null,
             watched_events: [],
             ignore_modifier_key_events: false,

--- a/js/src/events.ts
+++ b/js/src/events.ts
@@ -2,6 +2,10 @@ import {
     WidgetModel, WidgetView, DOMWidgetView, unpack_models
 } from '@jupyter-widgets/base';
 
+import {
+  JUPYTER_EXTENSION_VERSION
+} from './version';
+
 import * as _ from 'underscore';
 
 // The names in the lists below are what will be sent as part of the
@@ -89,6 +93,7 @@ class EventModel extends WidgetModel {
         return _.extend(super.defaults(), {
             _model_name: 'EventModel',
             _model_module: 'ipyevents',
+            _model_module_version: JUPYTER_EXTENSION_VERSION,
             source: null,
             watched_events: [],
             ignore_modifier_key_events: false,
@@ -311,4 +316,3 @@ function _click_location_original_image(view, event) {
     var image_y = Math.round(relative_click_y / view.el.height * view.el.naturalHeight);
     return {x: image_x, y: image_y}
 }
-

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -13,4 +13,3 @@ __webpack_public_path__ = document.querySelector('body').getAttribute('data-base
 
 // Export widget models and views, and the npm package version number.
 module.exports = require('./events.js');
-module.exports['version'] = require('../package.json').version;

--- a/js/src/plugin.ts
+++ b/js/src/plugin.ts
@@ -15,7 +15,7 @@ import {
 } from './events';
 
 import {
-  JUPYTER_EXTENSION_VERSION
+  NPM_VERSION
 } from './version';
 
 /**
@@ -37,7 +37,7 @@ export default ipyeventsPlugin;
 function activateWidgetExtension(app: Application<Widget>, registry: IJupyterWidgetRegistry): void {
   registry.registerWidget({
     name: 'ipyevents',
-    version: JUPYTER_EXTENSION_VERSION,
+    version: NPM_VERSION,
     exports: {
       EventModel: EventModel
     }

--- a/js/src/plugin.ts
+++ b/js/src/plugin.ts
@@ -1,0 +1,45 @@
+import {
+  Application, IPlugin
+} from '@phosphor/application';
+
+import {
+  Widget
+} from '@phosphor/widgets';
+
+import {
+  IJupyterWidgetRegistry
+ } from '@jupyter-widgets/base';
+
+import {
+  EventModel
+} from './events';
+
+import {
+  JUPYTER_EXTENSION_VERSION
+} from './version';
+
+/**
+ * The example plugin.
+ */
+const ipyeventsPlugin: IPlugin<Application<Widget>, void> = {
+  id: 'ipyevents',
+  requires: [IJupyterWidgetRegistry],
+  activate: activateWidgetExtension,
+  autoStart: true
+};
+
+export default ipyeventsPlugin;
+
+
+/**
+ * Activate the widget extension.
+ */
+function activateWidgetExtension(app: Application<Widget>, registry: IJupyterWidgetRegistry): void {
+  registry.registerWidget({
+    name: 'ipyevents',
+    version: JUPYTER_EXTENSION_VERSION,
+    exports: {
+      EventModel: EventModel
+    }
+  });
+}

--- a/js/src/version.ts
+++ b/js/src/version.ts
@@ -1,2 +1,13 @@
+/**
+ * The version of the attribute spec that this package
+ * implements. This is the value used in
+ * _model_module_version/_view_module_version.
+ *
+ * Update this value when attributes are added/removed from
+ * your models, or serialized format changes.
+ */
 export
-const JUPYTER_EXTENSION_VERSION = '1.0.0';
+const PROTOCOL_VERSION = '1.0.0';
+
+export
+const NPM_VERSION = require('../package.json').version;

--- a/js/src/version.ts
+++ b/js/src/version.ts
@@ -1,0 +1,2 @@
+export
+const JUPYTER_EXTENSION_VERSION = '1.0.0';


### PR DESCRIPTION
The only issue at the moment is that the JS version is hard-coded in 3 places (``JS_EXTENSION_VERSION``, ``JUPYTER_EXTENSION_VERSION``, and in ``package.json``). There must be a better way to do this?