### PR TITLE
Specify latest frontend version for jlab, embedding & voila

### DIFF
--- a/ipyevents/_version.py
+++ b/ipyevents/_version.py
@@ -20,4 +20,4 @@ __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
 #
 # Update this value when attributes are added/removed from
 # your models, or serialized format changes.
-EXTENSION_SPEC_VERSION = '1.3.1'
+EXTENSION_SPEC_VERSION = '1.3.2'

--- a/ipyevents/_version.py
+++ b/ipyevents/_version.py
@@ -20,4 +20,4 @@ __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
 #
 # Update this value when attributes are added/removed from
 # your models, or serialized format changes.
-EXTENSION_SPEC_VERSION = '1.2.0'
+EXTENSION_SPEC_VERSION = '1.3.1'

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipyevents",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A custom widget for returning mouse and keyboard events to Python",
   "author": "Matt Craig",
   "license": "BSD-3-Clause",

--- a/js/src/version.ts
+++ b/js/src/version.ts
@@ -7,4 +7,4 @@
  * your models, or serialized format changes.
  */
 export
-const EXTENSION_SPEC_VERSION = '1.2.0';
+const EXTENSION_SPEC_VERSION = '1.3.2';


### PR DESCRIPTION
This was causing the older version to be loaded, and 1.2.0 is not available on npmjs.

cf https://github.com/QuantStack/voila/issues/11