### PR TITLE
Add bounding rectangle information to returned event information

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,20 @@ $ jupyter labextension install @jupyter-widgets/jupyterlab-manager ipyevents
 
 For a development installation (requires npm),
 
-    $ git clone https://github.com/mwcraig/ipyevents.git
-    $ cd ipyevents
-    $ pip install -e .
-    $ jupyter nbextension install --py --symlink --sys-prefix ipyevents
-    $ jupyter nbextension enable --py --sys-prefix ipyevents
+```bash
+$ git clone https://github.com/mwcraig/ipyevents.git
+$ cd ipyevents
+$ pip install -e .
+$ jupyter nbextension install --py --symlink --sys-prefix ipyevents
+$ jupyter nbextension enable --py --sys-prefix ipyevents
+```
+
+For Jupyter Lab also do this:
+
+```bash
+$ cd js
+$ npm install
+$ npm run build
+$ jupyter labextension install
+```
+

--- a/doc/Widget DOM Events.ipynb
+++ b/doc/Widget DOM Events.ipynb
@@ -245,7 +245,18 @@
     "**Additional location for some types of widgets**\n",
     "+ `dataX`, `dataY`: Position of the mouse event in the underlying data object. For example, a click on an `Image` widget returns as `dataX` and `dataY` the coordinates of the click in the image. This location should be regarded as the *approximate* location the user intended given the difficulty of clicking accurately at the pixel level.\n",
     "\n",
-    "For widgets (like `Label`) for which there is no underlying array object these properties are not returned."
+    "For widgets (like `Label`) for which there is no underlying array object these properties are not returned.\n",
+    "\n",
+    "**Information about the on-screen size of the widget to which the `Event` is attached**\n",
+    "\n",
+    "The properties below are useful for things like computing the position of the mouse in some set of coordinates different than that provided by default. Using them is an alternative to writing your own widget that includes JavaScript for computing a custom mouse position and returning it in `dataX` and `dataY`, described above.\n",
+    "\n",
+    "From the [MDN documentation of bounding rectangle](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect), the bounding rectanlge \"is the smallest rectangle which contains the entire element\"; all values are in pixels.\n",
+    "\n",
+    "The positions are relative to the part of the page currently visible in the browser window, which are the same coordinates as `clientX` and  `clientY` for the mouse position.\n",
+    "\n",
+    "+ `boundingRectWidth`, `boundingRectHeight`: Width and height of the element in pixels.\n",
+    "+ `boundingRectTop`, `boundingRectLeft`, `boundingRectBottom`, `boundingRectRight`: Top, left, bottom and right positions of the upper left and lower right corners of the element, in the same coordiinates as the mouse position `clientX` and  `clientY`."
    ]
   },
   {

--- a/ipyevents/_version.py
+++ b/ipyevents/_version.py
@@ -1,7 +1,7 @@
 # What a full version specifier looks like:
 # version_info = (0, 0, 1, 'alpha', 0)
 
-version_info = (0, 4, 2, 'dev', 0)
+version_info = (0, 5, 0, 'dev', 0)
 
 _specifier_ = {
         'dev': 'dev',
@@ -20,4 +20,4 @@ __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
 #
 # Update this value when attributes are added/removed from
 # your models, or serialized format changes.
-EXTENSION_SPEC_VERSION = '1.4.1'
+EXTENSION_SPEC_VERSION = '1.5.0'

--- a/js/src/events.ts
+++ b/js/src/events.ts
@@ -10,7 +10,7 @@ import * as _ from 'underscore';
 
 // The names in the lists below are what will be sent as part of the
 // event message to the backend.
-// The actual list is constructed in _send_dom_message
+// The actual list is constructed in _send_dom_event
 
 let common_event_message_names = [
     'altKey',
@@ -45,6 +45,8 @@ let mouse_added_event_message_names = [
     'dataY',
     'relativeX',
     'relativeY',
+    'boundingRectWidth',
+    'boundingRectHeight',
     // Do NOT document the two below...they are deprecated.
     'arrayX',
     'arrayY'
@@ -346,6 +348,11 @@ class EventModel extends WidgetModel {
             event['dataX'] = data_coords.x
             event['dataY'] = data_coords.y
         }
+        // Also return the width/height of the bounding rectangle
+        var bounding_rect = generating_view.el.getBoundingClientRect()
+        event['boundingRectWidth'] = bounding_rect.width
+        event['boundingRectHeight'] = bounding_rect.height
+
         // The following is for backwards compatibility. It is deliberately
         // no longer in the documentation.
         if ('dataX' in event) {

--- a/js/src/events.ts
+++ b/js/src/events.ts
@@ -47,6 +47,10 @@ let mouse_added_event_message_names = [
     'relativeY',
     'boundingRectWidth',
     'boundingRectHeight',
+    'boundingRectTop',
+    'boundingRectLeft',
+    'boundingRectBottom',
+    'boundingRectRight',
     // Do NOT document the two below...they are deprecated.
     'arrayX',
     'arrayY'
@@ -348,10 +352,14 @@ class EventModel extends WidgetModel {
             event['dataX'] = data_coords.x
             event['dataY'] = data_coords.y
         }
-        // Also return the width/height of the bounding rectangle
+        // Also return the properties of the bounding rectangle
         var bounding_rect = generating_view.el.getBoundingClientRect()
         event['boundingRectWidth'] = bounding_rect.width
         event['boundingRectHeight'] = bounding_rect.height
+        event['boundingRectTop'] = bounding_rect.top
+        event['boundingRectLeft'] = bounding_rect.left
+        event['boundingRectBottom'] = bounding_rect.bottom
+        event['boundingRectRight'] = bounding_rect.right
 
         // The following is for backwards compatibility. It is deliberately
         // no longer in the documentation.

--- a/js/src/version.ts
+++ b/js/src/version.ts
@@ -7,4 +7,4 @@
  * your models, or serialized format changes.
  */
 export
-const EXTENSION_SPEC_VERSION = '1.4.1';
+const EXTENSION_SPEC_VERSION = '1.5.0';


### PR DESCRIPTION
Currently this adds only width and height, though it would be easy to add the remaining bits (top, left, right, bottom).

ping @astrofrog 