### PR TITLE
Fix dependencies to work with jupyterlab 1.0.0

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@phosphor/application": "^1.5.0",
     "@phosphor/widgets": "^1.5.0",
-    "@jupyter-widgets/base": "^1.0.4",
+    "@jupyter-widgets/base": "^1.0.4 || ^2",
     "@jupyter-widgets/controls": "^1.0.5",
     "lodash": "^4.17.4"
   },


### PR DESCRIPTION
As discussed in issue #44, this fixes #44.