### PR TITLE
MANIFEST.in: include various non-Python files needed to build the JS pieces

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,9 @@
 recursive-include ipyevents/nbextension/static *.*
+recursive-include src *.*
 
 include LICENSE.md
-
+include ipyevents.json
+include package.json
 include setupbase.py
+include tsconfig.json
+include webpack.config.js


### PR DESCRIPTION
I believe that the 0.6.1 package file on PyPI is more-or-less broken because it doesn't include package.json and the TypeScript source files: a `pip install` yields errors trying to build the Jupyter extension files. I think these changes get it working ... I can `pip install git+https://...@fix-package` and then the Jupyter extension works.