### PR TITLE
added basic touch functionality

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@
 + Sylvain Corlay ([@SylvainCorlay](https://github.com/SylvainCorlay))
 + Matt Craig ([@mwcraig](https://github.com/mwcraig)), maintainer
 + Simon Gurcke ([@itssimon](https://github.com/itssimon))
++ Alex Kaszynski ([@akaszynski](https://github.com/akaszynski))
 + Prabhu Ramachandran ([@prabhuramachandran](https://github.com/prabhuramachandran))
 + Waldemar Reusch ([@lordvlad](https://github.com/lordvlad))
 + Thomas Robitaille ([@astrofrog](https://github.com/astrofrog))

--- a/doc/Widget DOM Events.ipynb
+++ b/doc/Widget DOM Events.ipynb
@@ -54,7 +54,7 @@
     "l.layout.border = '2px solid red'\n",
     "\n",
     "h = HTML('Event info')\n",
-    "d = Event(source=l, watched_events=['click', 'keydown', 'mouseenter'])\n",
+    "d = Event(source=l, watched_events=['click', 'keydown', 'mouseenter', 'touchmove'])\n",
     "\n",
     "def handle_event(event):\n",
     "    lines = ['{}: {}'.format(k, v) for k, v in event.items()]\n",
@@ -149,7 +149,8 @@
    "outputs": [],
    "source": [
     "print('Key events: ', d.supported_key_events)\n",
-    "print('Mouse events: ', d.supported_mouse_events)"
+    "print('Mouse events: ', d.supported_mouse_events)\n",
+    "print('Touch events:', d.supported_touch_events)"
    ]
   },
   {
@@ -178,7 +179,16 @@
     "+ `mousedown` triggers when any mouse button is depressed.\n",
     "+ `mouseup` triggers when any mouse button is released.\n",
     "+ `mousemove` triggers every time the mouse moves over the widget. *Enabling this will generate a large volume of events between the front end and  the back end.*\n",
-    "+ `wheel` trigger when the user scrolls in any direction. *Note that watching this disables scrolling of the notebook while the mouse is over the watched widget.*\n"
+    "+ `wheel` trigger when the user scrolls in any direction. *Note that watching this disables scrolling of the notebook while the mouse is over the watched widget.*\n",
+    "\n",
+    "**Touch events**\n",
+    "\n",
+    "Touch events trigger on touch-enabled devices when something (e.g. a finger or a stylus) touches the screen. Touch events include information about all of the touch points on the screen, not just touch points within the watched widget. The touch event interface assumes that there may be multiple touch points.\n",
+    "\n",
+    "+ `touchstart` triggers when the watched element is touched.\n",
+    "+ `touchend` triggers when the touch point that triggered `touchstart` is removed from the screen or if the touch moves off the screen.\n",
+    "+ `touchmove` triggers when one or more of the touch points changes even if the touch is no longer over the target widget.\n",
+    "+ `touchcancel` triggers when something happens to inteerupt the touch (e.g. a dialog box pops up or there are too many touches on the screen)."
    ]
   },
   {
@@ -260,11 +270,11 @@
     "\n",
     "A mouse-related event has these keys in addition to the common ones above. They are broken into groups below to simplify the discussion. For more details about these properties, see the [MDN documentation of mouse events](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent).\n",
     "\n",
-    "**Which mouse button was pressed**\n",
+    "#### Which mouse button was pressed\n",
     "+ `button`: The button that was pushed or released for an event related to a mouse button push.\n",
     "+ `buttons`: The buttons that were depressed when a mouse-related event occurs whether or not the event was a click. For example, when the mouse moves onto a widget being watched for `mouseenter`, then `buttons` indicates which, if any, mouse buttons are being help down.\n",
     "\n",
-    "**Location of the mouse event**\n",
+    "### Location of the mouse event\n",
     "\n",
     "All locations are integers.\n",
     "\n",
@@ -276,12 +286,26 @@
     "+ `offsetX`, `offsetY`: Offset of this DOM element relative to its parents.\n",
     "+ `relativeX`, `relativeY`: The location of the mouse relative to the current element (i.e. widget). This emulates the functinoality of the `layerX/Y` attributes implemented in many browsers but not part of any standard.\n",
     "\n",
-    "**Additional location for some types of widgets**\n",
+    "### Additional location for some types of widgets\n",
+    "\n",
     "+ `dataX`, `dataY`: Position of the mouse event in the underlying data object. For example, a click on an `Image` widget returns as `dataX` and `dataY` the coordinates of the click in the image. This location should be regarded as the *approximate* location the user intended given the difficulty of clicking accurately at the pixel level.\n",
     "\n",
     "For widgets (like `Label`) for which there is no underlying array object these properties are not returned.\n",
     "\n",
-    "**Information about the on-screen size of the widget to which the `Event` is attached**\n",
+    "### Touch events only\n",
+    "\n",
+    "Touch events do not store locations directly. Instead, they store a list of touch points, each of which has location information. The top-level attributes unique to a touch event are\n",
+    "\n",
+    "+ `changedTouches`: a list of the touch points which have changed.\n",
+    "+ `targetTouches`: a list of all of the touch points which are still on the surface and which originated in the target widget.\n",
+    "+ `touches`: a list of all of the touch points on the surface, regardless of whether they have changed or originated in the target widget.\n",
+    "\n",
+    "Each of the touches in those lists contains:\n",
+    "\n",
+    "+ `identifier`: A unique identifier of the touch point.\n",
+    "+ The [position attributes for mouse events](#Location-of-the-mouse-event) and the [additional position information](#Additional-location-for-some-types-of-widgets) when it is available.\n",
+    "\n",
+    "### Information about the on-screen size of the widget to which the `Event` is attached\n",
     "\n",
     "The properties below are useful for things like computing the position of the mouse in some set of coordinates different than that provided by default. Using them is an alternative to writing your own widget that includes JavaScript for computing a custom mouse position and returning it in `dataX` and `dataY`, described above.\n",
     "\n",
@@ -560,13 +584,6 @@
    "source": [
     "no_drag.xy"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/ipyevents/events.py
+++ b/ipyevents/events.py
@@ -63,6 +63,9 @@ class Event(CoreWidget):
     supported_mouse_events
         List of mouse events that can be watched.
 
+    supported_touch_events
+        List of touch events that can be watched.
+
     supported_xy_coordinates
         List of supported xy coordinate systems that can be returned
         in `~ipyevents.Event.xy`.

--- a/ipyevents/events.py
+++ b/ipyevents/events.py
@@ -102,6 +102,13 @@ class Event(CoreWidget):
         'keyup'
     ]).tag(sync=True)
 
+    _supported_touch_events = List([
+        'touchstart',
+        'touchend',
+        'touchmove',
+        'touchcancel',
+    ]).tag(sync=True)
+
     _xy_coordinate_system_allowed = [
         None,       # Not tracking mouse x/y
         'data',     # "natural" coordinates for the widget (e.g. image)
@@ -134,6 +141,10 @@ class Event(CoreWidget):
         return self._supported_mouse_events
 
     @property
+    def supported_touch_events(self):
+        return self._supported_touch_events
+
+    @property
     def supported_xy_coordinates(self):
         return self._xy_coordinate_system_allowed
 
@@ -141,7 +152,8 @@ class Event(CoreWidget):
     def _validate_watched_events(self, proposal):
         value = proposal['value']
         supported_events = (self._supported_mouse_events +
-                            self._supported_key_events)
+                            self._supported_key_events +
+                            self._supported_touch_events)
         bad_events = [v for v in value if v not in
                       supported_events]
         if bad_events:

--- a/src/events.ts
+++ b/src/events.ts
@@ -119,6 +119,7 @@ class EventModel extends WidgetModel {
             throttle_or_debounce: null,
             _supported_mouse_events: [],
             _supported_key_events: [],
+            _supported_touch_events: [],
             _modifier_keys: ['Shift', 'Control', 'Alt', 'Meta']
         });
     }
@@ -133,12 +134,15 @@ class EventModel extends WidgetModel {
         this.prepare_source()
     }
 
-    key_or_mouse(event_type) {
+    key_mouse_or_touch(event_type) {
         if (_.contains(this.get('_supported_mouse_events'), event_type)) {
             return 'mouse'
         }
         if (_.contains(this.get('_supported_key_events'), event_type)) {
             return 'keyboard'
+        }
+        if (_.contains(this.get('_supported_touch_events'), event_type)) {
+            return 'touch'
         }
     }
 
@@ -206,10 +210,11 @@ class EventModel extends WidgetModel {
     _add_listeners_to_view(view) {
         // Add listeners for each of the watched events
         for (let event of this.get('watched_events')) {
-            switch (this.key_or_mouse(event)) {
+            switch (this.key_mouse_or_touch(event)) {
                 case "keyboard":
                     this._add_key_listener(event, view)
                     break
+                case "touch":
                 case "mouse":
                     let main_event_handler = this._throttle_or_debounce(this._dom_click.bind(this, view))
                     let event_propagation_handler = this._prevent_event_propagation.bind(this, view)
@@ -416,7 +421,8 @@ class EventModel extends WidgetModel {
         // Values are drawn from the DOM event object.
         let event_message = {target: {}}
         let message_names = []
-        switch (this.key_or_mouse(event.type)) {
+        switch (this.key_mouse_or_touch(event.type)) {
+            case "touch":
             case "mouse":
                 message_names = common_event_message_names.concat(mouse_standard_event_message_names)
                 message_names = message_names.concat(mouse_added_event_message_names)

--- a/src/events.ts
+++ b/src/events.ts
@@ -53,18 +53,12 @@ let mouse_and_touch_added_event_message_names = [
 let mouse_standard_event_message_names = [
     'button',
     'buttons',
-    // 'clientX',
-    // 'clientY',
     'layerX',
     'layerY',
     'movementX',
     'movementY',
     'offsetX',
     'offsetY',
-    // 'pageX',
-    // 'pageY',
-    // 'screenX',
-    // 'screenY',
     'x',
     'y'
 ]


### PR DESCRIPTION
### Touch Events

This PR adds a basic interface to the following touch events:

- ``'touchstart'``
- ``'touchend'``
- ``'touchmove'``
- ``'touchcancel'``

It's not perfect; ``_get_position`` doesn't work as touch events don't appear to have ``client*`` attributes, but they do have ``page*`` attributes that can be used instead to provide relative (x, y) coordinates.

It actually works quite well, though ideally ``mouse_standard_event_message_names`` would have a ``touch`` corollary (though, mouse events still work quite well).
